### PR TITLE
fix: corrigida a conversão de valores inteiros para decimais no exerc…

### DIFF
--- a/netbeans/curso-java-basico/src/com/loiane/cursojava/aula19/labs/Exer09.java
+++ b/netbeans/curso-java-basico/src/com/loiane/cursojava/aula19/labs/Exer09.java
@@ -33,7 +33,7 @@ public class Exer09 {
         }
         
         for (int i=0; i<vetorC.length; i++){
-            vetorC[i] = vetorA[i] / vetorB[i];
+            vetorC[i] = (double) vetorA[i] / vetorB[i];
         }
         
         System.out.print("Vetor A = ");
@@ -52,7 +52,7 @@ public class Exer09 {
         
         System.out.print("Vetor C = ");
         for (int i=0; i<vetorC.length; i++){
-            System.out.print(vetorC[i] + " ");
+            System.out.print(decimalFormat.format(vetorC[i]) + " ");
         }
         System.out.println();
     }    


### PR DESCRIPTION
Percebi que a conversão dos valores decimais no exercício não estava correta. Ao tentar corrigir o problema, identifiquei que a solução envolvia converter um dos operandos para double antes de realizar a divisão, garantindo assim o cálculo com casas decimais. Além disso, para assegurar a formatação adequada dos valores, foi necessário aplicar o `DecimalFormat` diretamente na impressão do vetor C, utilizando o código: `System.out.print(decimalFormat.format(vetorC[i]) + " ");`.

PS: Optei por usar `decimalFormat` em vez de `df`, como você costuma fazer, devido ao autocompletar do IntelliJ.